### PR TITLE
Import von time fehlt im GPIOZero Interrupt Beispiel - Button und LED

### DIFF
--- a/33-python2/hauptfolien.tex
+++ b/33-python2/hauptfolien.tex
@@ -100,6 +100,7 @@
         # Besipiel basierend auf https://www.ics.com/blog/control-raspberry-pi-gpio-pins-python
         from gpiozero import LED, Button
         import sys
+	import time
 
         led = LED(24)
         button = Button(6)

--- a/33-python2/hauptfolien.tex
+++ b/33-python2/hauptfolien.tex
@@ -100,7 +100,7 @@
         # Besipiel basierend auf https://www.ics.com/blog/control-raspberry-pi-gpio-pins-python
         from gpiozero import LED, Button
         import sys
-	import time
+        import time
 
         led = LED(24)
         button = Button(6)


### PR DESCRIPTION
Das Ausführen des Beispielprogrammes "GPIOZero Interrupt Beispiel - Button und LED" schlägt mit folgender Nachricht fehl:

```
Traceback (most recent call last):
  File "/home/pi/Documents/IoT/uebungenundtests/buttonandled.py", line 12, in <module>
    time.sleep(1)
NameError: name 'time' is not defined
```

Dies liegt daran, dass das time Modul nicht importiert wird.